### PR TITLE
corrected parcs input file construction with TH solvers

### DIFF
--- a/midas/codes/parcs343.py
+++ b/midas/codes/parcs343.py
@@ -302,7 +302,7 @@ def without_template(solution, input, cwd, filename):
     ## TH Block ##
     with open(filename,"a") as ofile:
         ofile.write("TH\n")
-        if input.th_fdbk:
+        if input.th_fdbk['apply'] and not input.th_fdbk['loc']:
             ofile.write("      FLU_TYP       0\n")
             ofile.write("      N_PINGT    264 25\n")
             ofile.write("      PIN_DIM      4.1 4.75 0.58 6.13\n")
@@ -314,7 +314,7 @@ def without_template(solution, input, cwd, filename):
             ofile.write(f"      THMESH_X       {dim_size[0]}*1\n")
             ofile.write(f"      THMESH_Y       {dim_size[1]}*1\n")
             ofile.write(f"      THMESH_Z       {str([x+1 for x in range(input.number_axial)]).strip('[]').replace(',','')}\n")
-        else:
+        elif not input.th_fdbk['apply']:
             ofile.write("      UNIF_TH   0.740    626.85     {}\n".format(np.round(input.inlet_temp-273.15,2))) #!TODO: how to deal with av. fuel temp?
         ofile.write("\n")
         ofile.write("!******************************************************************************\n\n")


### PR DESCRIPTION
fixed bug in parcs343.py. the PARCS input file writer was not properly handling TH solvers. There should be 3 options to the user. 1: no TH solver, 2: PARCS internal mass balance solver, 3: external PATHS solver. The writer was not properly handling the different scenarios.