### PR TITLE
removed INP_HST line

### DIFF
--- a/midas/codes/parcs343.py
+++ b/midas/codes/parcs343.py
@@ -324,7 +324,7 @@ def without_template(solution, input, cwd, filename):
         ofile.write("DEPL\n")
         if input.calculation_type == 'single_cycle':
             ofile.write(f"      TIME_STP  {str(input.depl_steps).strip('[]')}\n")
-        ofile.write("      INP_HST   './boc_exp.dep' -2 1\n")
+        # ofile.write("      INP_HST   './boc_exp.dep' -2 1\n") TODO add functionality in through input yaml files
         ofile.write("      OUT_OPT   T  T  T  T  F\n")
         # Write reflector cross sections
         ofile.write("      PMAXS_F   1 '{}{}' 1\n".format(input.xs_lib / Path(input.xs_list['reflectors']['bot'][0]),\


### PR DESCRIPTION
Commented out line that wrote INP_HST flag in PARCS input. I honestly do not know why this line was in the code to begin with. The INP_HST flag tells PARCS to start to calculation from a restart file which makes sense for MIDAS to handle this but it should not be the default. The line was commented out and a TODO marker was given so that the functionality can be properly added in at a later time.