### PR TITLE
removed indexing of setting in yaml file

### DIFF
--- a/midas/input_parser.py
+++ b/midas/input_parser.py
@@ -586,7 +586,7 @@ def validate_input(keyword, value):
                                 for subsubkey, subsubitem in subitem.items():
                                     new_subsubkey =str(subsubkey).lower().replace(' ','_')
                                     if new_subsubkey == 'type':
-                                        new_subsubitem = str(subsubitem)[0]
+                                        new_subsubitem = str(subsubitem)
                                     elif new_subsubkey == 'radii':
                                         new_subsubitem = [float(x) for x in re.split(r'[, ]',str(subsubitem).strip('[]')) if x]
                                     elif new_subsubkey == 'materials':


### PR DESCRIPTION
Removed "[0]" in line where the input parser reads in the user defined pin name for polaris models. I do not know why exactly it was like this in the first place but it doesn't make sense for it to be there anyway. Previously, if there were two pins names 1 and 10 respectively, MIDAS would read these both as 1 causing both pins to have the same material definition in polaris. The resulting polaris inputs would appear to have two different types of pins defined but in reality there is only 1 pin being defined.