### PR TITLE
added ipwr database file path to midas_data

### DIFF
--- a/midas/codes/nuscale_lut.py
+++ b/midas/codes/nuscale_lut.py
@@ -1,6 +1,7 @@
 import h5py
 import os
 import logging
+from midas_data import __ipwr_lut__
 
 ## Initialize logging for the present file
 logger = logging.getLogger("MIDAS_logger")
@@ -43,14 +44,15 @@ def read_hdf5(soln, input): #TODO!: Comment code better
             array containing loading pattern for NuScale SMR (8 assemblies)
 
     Written by Cole Howard. 10/29/2024
+    Updated by Jake Mikouchi. 12/16/25
     """
     individual = [input.fa_options['fuel'][sol]['type'] for sol in soln if sol in input.fa_options['fuel']]
     assembly_name = ''.join(map(str,individual))
     file_number = f'{individual[0]}{individual[1]}' #The number in the hdf5 file is the same as the first and second number of the loading pattern
-    filepath = f"/cm/shared/databases/SMR_IPWR_DATABASE/Solutions_{file_number}.hdf5"
+    filepath = f"{__ipwr_lut__}/Solutions_{file_number}.hdf5"
 
     if not os.path.exists(filepath): #Check here to make sure the file being looked up actually exists
-        raise FileNotFoundError(f'The file Solutions_{file_number}.hdf5 does not exist. Make sure all assemblies in the LP are between 2-7.')
+        raise FileNotFoundError(f'The file {filepath} does not exist. Make sure all assemblies in the LP are between 2-7.')
     #Open hdf5 file and index to the correct value, output the parameters
     with h5py.File(filepath,'r') as hdf5_file:
 

--- a/midas_data.py
+++ b/midas_data.py
@@ -39,3 +39,4 @@ __parcs342exe__ = "/cm1/codes/parcs_342/Executables/Linux/parcs-v342-linux2-inte
 __parcs343exe__ = "/cm/shared/nuclearCodes/parcs-3.4.3/PARCS-v343_Exe/Executables/Linux/parcs-v343-linux2-intel-x64-release.x"
 __trace50p5exe__ = "/cm1/apps/ncsu/TRACE_PARCS/TRACE-V50P5-Exe/Executables/trace-V50p5-linux2-lahey-x64-release.exe"
 __polaris624exe__ = "/cm/shared/codes/scale/SCALE-6.2.4/bin/scalerte"
+__ipwr_lut__ = "/cm/shared/databases/SMR_IPWR_DATABASE/"


### PR DESCRIPTION
Updated how the ipwr database file paths are provided to MIDAS. Previously the directory path for the database had to be defined in nuscale_lut.py which doesn't make sense and is confusing for users. I honestly do not know how this was allowed in the first place. The directory path is now defined in midas_data.py along with the executables. Also updated an error message to be more informative.