### PR TITLE
single cycle template bug fix

### DIFF
--- a/midas/codes/parcs343.py
+++ b/midas/codes/parcs343.py
@@ -435,7 +435,8 @@ def with_template(solution, input, cwd, filename):
 ## copy input file from template
     inp_template = str(cwd.joinpath(cwd / input.input_template['loc']))
     shutil.copy(inp_template, filename)
-    soln_full_core_lattice = prepare_shuffling_map(input, solution.chromosome)
+    if input.calculation_type in ['eq_cycle']:
+        soln_full_core_lattice = prepare_shuffling_map(input, solution.chromosome)
 
     with open(filename, "r") as file:
         lines = file.readlines()  


### PR DESCRIPTION
Added if statement so that shuffling schemes are only constructed if an equilibrium cycle optimization is selected. Otherwise MIDAS would try to use nonexistent variables to constructed the shuffling scheme causing errors.