### PR TITLE
fixed convergence plot wording

### DIFF
--- a/midas/input_parser.py
+++ b/midas/input_parser.py
@@ -1104,7 +1104,7 @@ class Input_Parser():
         self.input_template = yaml_line_reader(info, 'input_template', template_default)
         self.calculation_type = yaml_line_reader(info, 'calc_type', 'single_cycle')
         self.statistics_plots = yaml_line_reader(info, 'statistics_plots', True)
-        self.convergence_plot = yaml_line_reader(info, 'convergence_plot', True)
+        self.convergence_plots = yaml_line_reader(info, 'convergence_plots', True)
         self.initial_population = yaml_line_reader(info, 'initial_population', None)
         if self.input_template['apply'] and self.code_interface == 'parcs343':
             parcs343_template_check(self)

--- a/midas/optimizer.py
+++ b/midas/optimizer.py
@@ -430,7 +430,7 @@ class Optimizer():
         if self.input.statistics_plots:
             optimization_information.plot_optimization_statistics()
         #Plot convergence if user turned on convergence
-        if self.input.convergence_plot:
+        if self.input.convergence_plots:
             optimization_information.plot_optimization_convergence()
     
         return


### PR DESCRIPTION
convergence plot wording was inconsistent in input_parser.py making the flag in the yaml file do nothing. Fixed it to be consistent with other plot flags and the user manual.