### PR TITLE
parameterization

### DIFF
--- a/midas/codes/parcs343.py
+++ b/midas/codes/parcs343.py
@@ -307,14 +307,14 @@ def without_template(solution, input, cwd, filename):
             ofile.write("      PIN_DIM      {}\n".format(input.pin_dimensions))
             ofile.write("      FLOW_COND    {}  {}\n".format(np.round(input.inlet_temp-273.15,2),\
                                                             np.round(input.flow/input.num_assemblies,4)))
-            ofile.write("      STATE_CORE   {}  1301.86  1.5789E7\n".format(np.round(input.flow)))
             ofile.write("      HGAP     11356.0\n") #!TODO:check this value, should it be parameterized?
             ofile.write("      N_RING   6\n")
             ofile.write(f"      THMESH_X       {dim_size[0]}*1\n")
             ofile.write(f"      THMESH_Y       {dim_size[1]}*1\n")
             ofile.write(f"      THMESH_Z       {str([x+1 for x in range(input.number_axial)]).strip('[]').replace(',','')}\n")
         elif not input.th_fdbk['apply']:
-            ofile.write("      UNIF_TH   0.740    626.85     {}\n".format(np.round(input.inlet_temp-273.15,2))) #!TODO: how to deal with av. fuel temp?
+            ofile.write("      UNIF_TH   {}    {}     {}\n".format(input.coolant_dens, np.round(input.fuel_temp-273.15,2),\
+                                            np.round(input.inlet_temp-273.15,2))) 
         ofile.write("\n")
         ofile.write("!******************************************************************************\n\n")
 

--- a/midas/input_parser.py
+++ b/midas/input_parser.py
@@ -852,6 +852,12 @@ def validate_input(keyword, value):
     
     elif keyword == 'inlet_temperature':
         value = float(value)
+
+    elif keyword == 'coolant_density':
+        value = float(value)
+
+    elif keyword == 'fuel_temperature':
+        value = float(value)
     
     elif keyword == 'th_fdbk':
         if isinstance(value, dict):
@@ -1266,6 +1272,8 @@ class Input_Parser():
         self.power = yaml_line_reader(info, 'power', 3800.0)
         self.flow = yaml_line_reader(info, 'flow', 18231.89)
         self.inlet_temp = yaml_line_reader(info, 'inlet_temperature', 565.0)
+        self.coolant_dens = yaml_line_reader(info, 'coolant_density', 0.740)
+        self.fuel_temp = yaml_line_reader(info, 'fuel_temperature', 900.0)
         th_default = {'apply':True, 'loc': None}
         self.th_fdbk = yaml_line_reader(info, 'th_fdbk', th_default)
         self.pin_power_recon = yaml_line_reader(info, 'pin_power_recon', True)


### PR DESCRIPTION
added in parameterization for fuel temperature and coolant density when running parcs with uniform state variables (no th feedback). Also removed an unnecessary flag that was being printed in parcs inputs.