### PR TITLE
pinpower bugfix

### DIFF
--- a/midas/utils/problem_preparation.py
+++ b/midas/utils/problem_preparation.py
@@ -325,7 +325,7 @@ class Prepare_Problem_Values():
                     pincal_loc[x,y]=0
                 elif loc == "00":
                     if input_obj.map_size == 'quarter':
-                        pincal_loc[x,y]=float('NaN')
+                        pincal_loc[x,y]=' '
                     else: #assume full geometry for printing
                         pincal_loc[x,y] = ' '
                 else:


### PR DESCRIPTION
Fixed bug where, if PARCS was run with quarter core symmetry and pin power reconstruction was turned on, then a bunch of locations on the pin reconstruction map were set to Nan rather than a blank space causing errors with PARCS.