### PR TITLE
Preparation

### DIFF
--- a/midas/codes/polaris624.py
+++ b/midas/codes/polaris624.py
@@ -185,9 +185,7 @@ def evaluate(solution, input):
         ofile.write("%\n% % % % % % % % % % % %\n% %   STATEPOINTS   % %\n% % % % % % % % % % % %\n%\n")
         ofile.write("% Properties of stated materials\n")
         ofile.write(f"state ALL : temp={input.bulk_temps} ")
-        for name, mat in input.pin_options['materials'].items():
-            if mat['fueltype']:
-                ofile.write(f" {name.split('.')[0]} : temp={input.fuel_temps} ")
+        ofile.write(f" FUEL : temp={input.fuel_temps} ")
         if 'control_rods' in input.pin_options.keys():
             ofile.write(f" BankA : in={str(input.cr_inserted).lower()} ")
         if input.boronmat:
@@ -195,9 +193,7 @@ def evaluate(solution, input):
         ofile.write("%\n")
         ofile.write(f"power {input.powdens} %W/gIHM\n%\n")
         ofile.write("deplete")
-        for name, mat in input.pin_options['materials'].items():
-            if mat['fueltype']:
-                ofile.write(f" {name.split('.')[0]}=True")
+        ofile.write(f" FUEL=True")
         ofile.write("\n")
         ofile.write(f"bu")
         for step in input.depl_steps:

--- a/midas/codes/polaris624.py
+++ b/midas/codes/polaris624.py
@@ -185,7 +185,9 @@ def evaluate(solution, input):
         ofile.write("%\n% % % % % % % % % % % %\n% %   STATEPOINTS   % %\n% % % % % % % % % % % %\n%\n")
         ofile.write("% Properties of stated materials\n")
         ofile.write(f"state ALL : temp={input.bulk_temps} ")
-        ofile.write(f" FUEL : temp={input.fuel_temps} ")
+        for name, mat in input.pin_options['materials'].items():
+            if mat['fueltype']:
+                ofile.write(f" {name} : temp={input.fuel_temps} ")
         if 'control_rods' in input.pin_options.keys():
             ofile.write(f" BankA : in={str(input.cr_inserted).lower()} ")
         if input.boronmat:
@@ -193,7 +195,9 @@ def evaluate(solution, input):
         ofile.write("%\n")
         ofile.write(f"power {input.powdens} %W/gIHM\n%\n")
         ofile.write("deplete")
-        ofile.write(f" FUEL=True")
+        for name, mat in input.pin_options['materials'].items():
+            if mat['fueltype']:
+                ofile.write(f" {name}=True")
         ofile.write("\n")
         ofile.write(f"bu")
         for step in input.depl_steps:


### PR DESCRIPTION
Fixed bug where fuel temperature was printed to polaris input file multiple times causing errors in Polaris. For every fuel material defined, a statement was made in the input file saying "FUEL : temp=..." and if the fuel temperature is stated multiple times then Polaris will give an error. This was changed so that each individual fuel material temperature is printed so the statements becomes "FUEL.1 : temp=...  FUEL.2 : temp=...  FUEL.3 : temp=..." which does not give errors. This same error existed and was fixed for defining if a material is depleted. 