### PR TITLE
updated parcs inputs

### DIFF
--- a/midas/codes/parcs343.py
+++ b/midas/codes/parcs343.py
@@ -370,9 +370,11 @@ def without_template(solution, input, cwd, filename):
                     val = input.full_core_locs[x,y]
                     try:
                         if not np.isnan(val):
+                            ofile.write("  ")
                             ofile.write(str(input.full_core_locs[x,y]))
                             ofile.write("  ")
                     except TypeError:
+                        ofile.write("  ")
                         ofile.write(str(input.full_core_locs[x,y]))
                         ofile.write("  ")
                 ofile.write("\n")
@@ -382,13 +384,14 @@ def without_template(solution, input, cwd, filename):
             for x in range(soln_full_core_lattice.shape[0]):
                 for y in range(soln_full_core_lattice.shape[1]):
                     val = soln_full_core_lattice[x,y]
+                    ofile.write("  ")
                     ofile.write(str(soln_full_core_lattice[x,y]))
                     ofile.write("  ")
                 ofile.write('\n')
             ofile.write('\n')
             
             ofile.write("    CYCLE_IND    1  0  1\n")
-            max_convergence_cycles = 10 #!TODO: this max number of cycles could easily be a parameter.
+            max_convergence_cycles = input.equilibrium_cycles #!TODO: this max number of cycles could easily be a parameter.
             for i in range(2,max_convergence_cycles+1):
                 ofile.write(f"    CYCLE_IND    {i}  1  1\n")
             ofile.write(f"    CONV_EC    0.1  {i}\n")

--- a/midas/input_parser.py
+++ b/midas/input_parser.py
@@ -929,6 +929,9 @@ def validate_input(keyword, value):
                     new_value.append(float(step))
         return new_value
     
+    elif keyword == 'equilibrium_cycles':
+        value = int(value)
+
     ## TRACE DATA ##
     elif keyword == 'initialize_code':
         value = str(value).lower().replace(' ','_')
@@ -1284,8 +1287,10 @@ class Input_Parser():
         self.axial_nodes = yaml_line_reader(info, 'axial_nodes', [16.12, "15*25.739", 16.12])
         self.boc_exposure = yaml_line_reader(info, 'boc_core_exposure', 0.0)
         self.depl_steps = yaml_line_reader(info, 'depletion_steps', [1, 1, 30, 30, 30, 30, 30, 30])
+        self.equilibrium_cycles = yaml_line_reader(info, "equilibrium_cycles", 10)
         if (not self.pin_power_recon and 'pinpowerpeaking' in self.objectives.keys()) or (not self.pin_power_recon and 'fdeltah' in self.objectives.keys()):
             logger.warning('Pin power reconstruction is turned off but pin peaking factors are requested in objectives.')
+            
         self.active_cycles = yaml_line_reader(info, "active_cycles", 500)
         self.inactive_cycles = yaml_line_reader(info, "inactive_cycles", 50)
         self.particles_per_history = yaml_line_reader(info, "particles_per_history", 5000)


### PR DESCRIPTION
fixed bug in PARCS equilibirum input file creator and added parmeterization.

lines 373, 377, 387:
Added spaces before each row of the core layout and shuffle map. Originally, the layout and shuffle maps would be printed starting at the left most column, however PARCS reserves the first column in each line for Block names. Given that the core layout and shuffle maps are not blocks, this would cause errors and the computation was not completed.

line 394 + input parser:
Added the ability to specify the number of cycles and equilibrium core will be run to.

